### PR TITLE
remove use of [core] domain module - due to it being deprecated

### DIFF
--- a/lib/shutdown-coordinator.js
+++ b/lib/shutdown-coordinator.js
@@ -2,8 +2,7 @@
 'use strict';
 
 var asyncModule = require('async');
-var domain = require('domain');
-var debug = require('debug')('shutdown');
+var debug = require('debug')('shutdown')
 
 function ShutdownCoordinator(options) {
   this.handlers = {};
@@ -80,44 +79,32 @@ ShutdownCoordinator.prototype = {
       return function(stageCallback) {
         asyncModule.parallel(stageHandlers.map(function(handler) {
           return function(handlerCallback) {
-            var st;
+            // Stage timeout
+            var st = setTimeout(function() {
+              console.error(handler.name + " shutdown handler did not complete in a timely manner");
+              if (handlerCallback) {
+                handlerCallback();
 
-            var d = domain.create();
-            d.on('error', function(err) {
-              clearTimeout(st);
-
-              console.error(handler.name + ' handler failed during shutdown: ' + err);
-              handlerCallback();
-            });
-
-            d.run(function() {
-              // Stage timeout
-              var st = setTimeout(function() {
-                console.error(handler.name + ' shutdown handler did not complete in a timely manner');
-                if(handlerCallback) {
-                  handlerCallback();
-                }
-              }, stageTimeout);
-              st.unref();
-
-              // Call the handler
-              try {
-                debug('Initiating shutdown of %s', handler.name);
-
-                handler.handler(function(err) {
-                  if(err) {
-                    console.error(handler.name + ' handler failed during shutdown: ' + err);
-                  }
-
-                  clearTimeout(st);
-                  handlerCallback();
-                });
-              } catch(e) {
-               clearTimeout(st);
-               handlerCallback();
               }
-            });
+            }, stageTimeout);
+            st.unref();
 
+            // Call the handler
+            try {
+              debug('Initiating shutdown of %s', handler.name);
+
+              handler.handler(function(err) {
+                if(err) {
+                  console.error(handler.name + " handler failed during shutdown: " + err);
+                }
+
+                clearTimeout(st);
+                handlerCallback();
+              });
+            } catch(e) {
+             clearTimeout(st);
+             handlerCallback();
+            }
           };
         }), function(err) {
           /* err should never happen, but anyway */


### PR DESCRIPTION
the domain module is marked as deprecated ([see here](https://nodejs.org/api/domain.html)), I think it is wise to remove it.

Removing it's usage does not have any effect on normal shutdown operation.

Given that uncaught exceptions should be treated as a stop-the-world situation *and* we are already shutting down in this context I feel that no love is lost.

**What do you think?**